### PR TITLE
use default nat network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - 3000:3000
     depends_on:
       - api
+    networks:
+      - nat
 
   api:
     build: ./api
@@ -17,10 +19,18 @@ services:
       - 8081:80
     depends_on:
       - database
-  
+    networks:
+      - nat
+
   database:
     build: ./database
     image: mssql:latest
     environment:
       - ACCEPT_EULA=Y 
       - sa_password=P@ssw0rd
+    networks:
+      - nat
+
+networks:
+  nat:
+    external: true


### PR DESCRIPTION
This PR plugs all containers into the default nat network - without this, I get:

```
PS: node-0 fundamentals-final-win>docker-compose up -d
Creating network "fundamentals-final-win_default" with the default driver
ERROR: HNS failed with error : The parameter is incorrect.
```